### PR TITLE
fix: prevent demo site from being indexed 🐛

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -28,6 +28,7 @@ const {
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/png" href="/favicon.png" />
 		<meta name="generator" content={Astro.generator} />
+		<meta name="robots" content="noindex, nofollow" />
 		<title>{title}</title>
 	</head>
 	<body

--- a/src/pages/diensten/index.astro
+++ b/src/pages/diensten/index.astro
@@ -16,21 +16,21 @@ const services = [
         description:
             "Wij komen bij u langs om uw wensen in kaart te brengen en maken een gedetailleerd 3D-ontwerp van uw toekomstige tuin.",
         icon: PencilRuler,
-        href: "/diensten/tuinontwerp",
+        href: "/diensten/tuinontwerp/",
     },
     {
         title: "Tuinaanleg",
         description:
             "Van ontwerp tot oplevering. Wij combineren straatwerk, borders, bomen en buitenverblijven tot een tuin waarin u echt tot rust kunt komen.",
         icon: Shovel,
-        href: "/diensten/tuinaanleg",
+        href: "/diensten/tuinaanleg/",
     },
     {
         title: "Grondwerk",
         description:
             "Een goede basis voor uw buitenleven. Of het nu gaat om uitgraven, egaliseren of voorbereidend werk – wij zorgen dat alles tot in de bodem goed zit.",
         icon: Mountain,
-        href: "/diensten/grondwerk",
+        href: "/diensten/grondwerk/",
     },
 ];
 ---


### PR DESCRIPTION
## Summary
- Add `<meta name="robots" content="noindex, nofollow">` to Layout head so all pages are protected from search engine indexing
- Fix 3 missing trailing slashes on diensten service links

## Why both `robots.txt` and `noindex`?
- `robots.txt` prevents crawling, but Google can still index URLs discovered via external links
- The `noindex` meta tag tells Google to drop pages from search results entirely

Closes #5